### PR TITLE
Nuget trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,21 @@ jobs:
     name: build, pack and release
     runs-on: windows-latest
 
+    permissions:
+      id-token: write
+    
     steps:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+
     - uses: dotnet/nbgv@master
       with:
         setAllVars: true
@@ -37,13 +43,19 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release create v${{ env.NBGV_SemVer2 }} --title v${{ env.NBGV_SemVer2 }} --generate-notes
-    
+
+    - name: NuGet login
+      uses: NuGet/login@v1
+      id: nugetlogin
+      with:
+        user: ${{ secrets.NUGET_USER }}
+          
     - name: Publish to nuget
       run: |
         Get-ChildItem artifacts -Filter *.nupkg | ForEach-Object {
           dotnet nuget push $_.FullName `
             --source https://api.nuget.org/v3/index.json `
-            --api-key ${{ secrets.NUGET_API_KEY }} `
+            --api-key ${{ steps.nugetlogin.outputs.NUGET_API_KEY }} `
             --skip-duplicate
         }
       shell: pwsh


### PR DESCRIPTION
- Remove nuget api key and use trusted publishing
- Update actions/setup-dotnet
- Disable setup-dotnet telemetry
